### PR TITLE
fix: use logger.info instead of logger.log in activate()

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -94,7 +94,7 @@ module.exports = {
    * ACTIVATE
    */
   async activate(opts = {}) {
-    logger.log(`(SEARCH/MEILISEARCH) Activating search engine...`, opts);
+    logger.info(`(SEARCH/MEILISEARCH) Activating search engine...`);
     const engine = await getSearchEngine(this.config);
     logger.info(`(SEARCH/MEILISEARCH) Engine methods: ${Object.keys(engine)}`);
     await engine.activated();


### PR DESCRIPTION
Wiki.js's logger is backed by winston, where logger.log(level, msg) treats its first argument as the log level. Passing the message string as the level caused an \"Unknown logger level\" error and crashed activate() before the search engine was initialized, breaking the Apply flow in the admin panel.

fix #24 `colors[Colorizer.allColors[lookup]] is not a function`