### PR TITLE
ci: use default GITHUB_TOKEN for release step

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -79,5 +79,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           gh release upload "$VERSION" meilisearch.zip --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # The job-level `contents: write` permission scopes this token —
+          # no custom PAT needed. The previous `secrets.GH_TOKEN` PAT was
+          # failing GitHub's GraphQL API ("unexpected GraphQL response
+          # shape fetching tags"), most likely expired/under-scoped; the
+          # same query succeeds against this repo with a normal token.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Follow-up to #28. The first automated release run (from the #28 merge) failed at the new "Tag and publish release" step:

```
semver: couldn't auto-detect PR labels ... unexpected commits/pulls response shape
Error: unexpected GraphQL response shape fetching tags
```

Reproduced the same GraphQL query (`get_last_tag`) against this repo manually with a normal token and it returns data fine, so the `secrets.GH_TOKEN` PAT (set 2025-03-15) is the likely culprit — expired or under-scoped for the GraphQL API. Swaps it for the workflow's own `secrets.GITHUB_TOKEN`, now that the job has `permissions: contents: write`, removing the custom-PAT dependency entirely.

## Test plan
- [ ] CI passes on this PR
- [ ] Merging to `main` successfully tags/releases `v0.0.5` with the zip asset attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqB3SimxgG6Zbc4bniCb7V