### PR TITLE
ci: run fmt/clippy/build through paws ci

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -20,18 +20,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
+      - name: Install paws
+        uses: mbround18/paws/actions/paws-up@main
 
-      - name: Rustfmt Check
-        uses: actions-rust-lang/rustfmt@v1
-
-      - name: Clippy Check
-        run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
+      # Runs fmt/clippy(-D warnings)/build against wasm32-unknown-unknown
+      # inside an ephemeral Dagger container — paws-rust auto-detects the
+      # wasm-bindgen/cdylib shape from Cargo.toml. This replaces the old
+      # actions-rust-lang/setup-rust-toolchain + rustfmt + clippy + 3x
+      # actions/cache steps; it's a separate, disposable environment from
+      # the actual pkg/ build below, so it doesn't leave a rust toolchain
+      # on the runner — that's still needed for `make build`'s wasm-pack
+      # step, which paws doesn't do (it only lints/builds, no packaging).
+      - name: paws ci
+        run: paws ci --toolchain rust
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -65,12 +66,6 @@ jobs:
       # labels/branch inference (see mbround18/paws) instead of a
       # hand-maintained VERSION file — the file drifting out of sync with
       # the tags is what silently stopped releases from firing.
-      - name: Install paws
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: mbround18/paws/actions/paws-up@main
-        with:
-          install-dagger: "false"
-
       - name: Tag and publish release
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         id: release


### PR DESCRIPTION
## Summary
Follow-up to #28/#29, and to `mbround18/paws#10` which added wasm-bindgen/wasm-pack detection to `paws ci --toolchain rust`.

- Replaces `actions-rust-lang/setup-rust-toolchain` + the separate `Rustfmt Check`/`Clippy Check` steps with `mbround18/paws/actions/paws-up@main` + `paws ci --toolchain rust`. `paws-rust` auto-detects this crate's wasm-bindgen/cdylib shape from `Cargo.toml` and runs the same fmt/clippy(`-D warnings`)/build sequence against `wasm32-unknown-unknown` — but through a disposable Dagger container, not the runner's own toolchain.
- The actual `pkg/` build (`make setup && make build`, wasm-pack) is unchanged — `paws` doesn't do artifact packaging, so that still needs a real rustup/wasm-pack toolchain on the runner. Cargo caches and `Setup System` are untouched.
- The release step (`paws semver --push`, from #29) is unchanged.

## Test plan
- [ ] CI passes on this PR (verifies `paws ci --toolchain rust` actually lints/builds this crate correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqB3SimxgG6Zbc4bniCb7V